### PR TITLE
Adding Form feature

### DIFF
--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -14,6 +14,11 @@ html {
   src: url(../fonts/Poppins/Poppins-Medium.ttf);
 }
 
+@font-face {
+  font-family: Poppins-thin;
+  src: url(../fonts/Poppins/Poppins-Light.ttf);
+}
+
 body {
   margin-top: 48.34px;
   font-family: Poppins, serif;
@@ -503,4 +508,66 @@ body {
 
 .css_icon {
   background: center no-repeat url(../icons/css_icon.svg);
+}
+.contact_form {
+  background-color: #6070ff;
+  padding: 80px 20px 40px 20px;
+  border-top-left-radius: 5rem;
+  color: white;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.contact__form {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-bottom: 20px;
+  gap: 15px;
+}
+.contact__title, .contact__paragraph {
+  width: fit-content;
+  align-self: center;
+}
+.contact__title {
+  font-size: 40px;
+  font-weight: 700;
+}
+.contact__paragraph {
+  font-family: Poppins-thin;
+  text-align: center;
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: lighter;
+}
+.form__list__ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.form__list__ul li {
+  display: flex;
+  flex-direction: column;
+}
+.input__li {
+  flex-grow: 1;
+}
+.submit__form {
+  width: fit-content;
+  padding: 10px;
+  color:  #6070FF;
+}
+.input__name, .input__mail {
+  padding: 5px;
+  height: 48px;
+}
+.input__name, .input__mail, .input__message, .submit__form{
+  border-radius: 8px;
+  outline: none;
+  border: unset;
+}
+.input__message {
+  height: 8rem;
+  padding: 10px;
 }

--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -509,6 +509,7 @@ body {
 .css_icon {
   background: center no-repeat url(../icons/css_icon.svg);
 }
+
 .contact_form {
   background-color: #6070ff;
   padding: 80px 20px 40px 20px;
@@ -518,6 +519,7 @@ body {
   flex-direction: column;
   justify-content: center;
 }
+
 .contact__form {
   display: flex;
   flex-direction: column;
@@ -525,48 +527,63 @@ body {
   margin-bottom: 20px;
   gap: 15px;
 }
-.contact__title, .contact__paragraph {
+
+.contact__title,
+.contact__paragraph {
   width: fit-content;
   align-self: center;
 }
+
 .contact__title {
   font-size: 40px;
   font-weight: 700;
 }
+
 .contact__paragraph {
-  font-family: Poppins-thin;
+  font-family: Poppins-thin, serif;
   text-align: center;
   font-size: 20px;
   line-height: 28px;
   font-weight: lighter;
 }
+
 .form__list__ul {
   list-style: none;
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
+
 .form__list__ul li {
   display: flex;
   flex-direction: column;
 }
+
 .input__li {
   flex-grow: 1;
 }
+
 .submit__form {
   width: fit-content;
   padding: 10px;
-  color:  #6070FF;
+  color: #6070ff;
 }
-.input__name, .input__mail {
+
+.input__name,
+.input__mail {
   padding: 5px;
   height: 48px;
 }
-.input__name, .input__mail, .input__message, .submit__form{
+
+.input__name,
+.input__mail,
+.input__message,
+.submit__form {
   border-radius: 8px;
   outline: none;
   border: unset;
 }
+
 .input__message {
   height: 8rem;
   padding: 10px;

--- a/index.html
+++ b/index.html
@@ -172,5 +172,29 @@
         <hr>
     </div>
   </section>
+  <section class="contact_form">
+    <div class="contact__form">
+        <h2 class="contact__title">Contact me</h2>
+        <p class="contact__paragraph">If you have an application you are interested in developing, a feature that you need built or a project that needs coding. I’d love to help with it </p>
+    </div>
+    <form action="https://formspree.io/f/xgebklbg" method="post">
+        <ul>
+            <li>
+                <label for="name">Name</label>
+                <input type="text" id="name" maxlength="30" placeholder="Enter your name" required>
+            </li>
+            <li>
+                <label for="email">Email</label>
+                <input type="email" id="email" placeholder="Enter your email" required>
+            </li>
+            <li>
+                <textarea name="message" id="message" maxlength="500" placeholder="Write your message here" required></textarea>
+            </li>
+            <li>
+                <button type="submit">Get in touch</button>
+            </li>
+        </ul>
+    </form>
+  </section>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -177,21 +177,21 @@
         <h2 class="contact__title">Contact me</h2>
         <p class="contact__paragraph">If you have an application you are interested in developing, a feature that you need built or a project that needs coding. I’d love to help with it </p>
     </div>
-    <form action="https://formspree.io/f/xgebklbg" method="post">
-        <ul>
+    <form action="https://formspree.io/f/xgebklbg" method="post" class="form__list">
+        <ul class="form__list__ul">
             <li>
-                <label for="name">Name</label>
-                <input type="text" id="name" maxlength="30" placeholder="Enter your name" required>
+                <label for="name"></label>
+                <input class="input__li input__name" type="text" id="name" maxlength="30" placeholder="Enter your name" required>
             </li>
             <li>
-                <label for="email">Email</label>
-                <input type="email" id="email" placeholder="Enter your email" required>
+                <label for="email"></label>
+                <input class="input__li input__mail" type="email" id="email" placeholder="Enter your email" required>
             </li>
             <li>
-                <textarea name="message" id="message" maxlength="500" placeholder="Write your message here" required></textarea>
+                <textarea class="input__li input__message" name="message" id="message" maxlength="500" placeholder="Write your message here" required></textarea>
             </li>
             <li>
-                <button type="submit">Get in touch</button>
+                <button class="submit__form" type="submit">Get in touch</button>
             </li>
         </ul>
     </form>


### PR DESCRIPTION
## 📱 Adding form feature in contact section

**Description:** This pull request update the previous merged PR by adding a submit form📱 designed with mobile-first functionality in mind, using HTML and CSS with Grid and Flexbox 📐. 
The page includes now:
-  navigation bar with a logo 📸 ("Logo" by default as in the template) and hamburger menu, 
- a section containing information about the portfolio's owner ✍️, and a list of his contacts 📧.
- a section containing works cards (done projects) about the portfolio's owner ✍️, a list 📧.of languages used by project, and a go live button (see project).
- a section containing languages and skills and a short summary about the portfolio's owner ✍️.
- the last section with a contact form that collect users data and send them to my email using the [Formspree service](https://formspree.io/).

_I've collaborate with my codding partner to make this form as required_

Great regards